### PR TITLE
Ensure anchors containing not-well-formed HTML <img> tags still works in retconOnly

### DIFF
--- a/src/services/RetconService.php
+++ b/src/services/RetconService.php
@@ -472,8 +472,7 @@ class RetconService extends Component
 
         /** @var \DOMElement $node */
         foreach ($nodes as $node) {
-            $outerHtml = $node->ownerDocument->saveHTML($node);
-            $fragment->appendXML($outerHtml);
+            $fragment->appendChild($node);
         }
 
         $body = $doc->getElementsByTagName('body')->item(0);


### PR DESCRIPTION
In HTML5 it's valid to have markup such as the following:

```
<a href="http://example.com">
  <img src="http://example.com/sample.jpg">
</a>
```

However, the above is not XML as the `<img>` tag is not well-formed.

The above markup caused the retcon `only` function to break, as it's using `appendXML`  to add the HTML fragment, so in this PR we fallback to using the `appendChild` method which works.
